### PR TITLE
Wagtail 2 fixes

### DIFF
--- a/wagtailcomments_xtd/templates/wagtailcomments_xtd/comments/_list_explore.html
+++ b/wagtailcomments_xtd/templates/wagtailcomments_xtd/comments/_list_explore.html
@@ -32,10 +32,10 @@
 					{% endif %}
 				</ul>
 			</td>
-			<td class="updated" valign="top">
-				{{ element.comment.submit_date|date:"d M Y H:i" }}
+			<td class="human-readable-date" title="{{ element.comment.submit_date|date:"d M Y H:i" }}" valign="top">
+        {{ element.comment.submit_date|timesince }} ago
 			</td>
-			<td>
+			<td class="status" valign="top">
 				{% if not element.comment.is_public %}
 					<span class="status-tag">{% trans "Deleted" %}</span>
 				{% elif element.comment.is_removed %}

--- a/wagtailcomments_xtd/templates/wagtailcomments_xtd/comments/_list_explore.html
+++ b/wagtailcomments_xtd/templates/wagtailcomments_xtd/comments/_list_explore.html
@@ -1,11 +1,11 @@
 {% load i18n %}
-{% load gravatar %}
+{% load comments_xtd %}
 
 <tbody>
 	{% for element in comments %}
 		<tr class="">
-			<td class="ord">
-				<span class="avatar icon icon-user" style="top:0;"><img src="{% gravatar_url element.comment.user_email %}" /></span>
+			<td class="ord" valign="top">
+				<span class="avatar small" style="top:0;"><img src="{{ element.comment.user_email|xtd_comment_gravatar_url }}" /></span>
 			</td>
 			<td class="title" valign="top" data-listing-page-title="">
 				<h2>

--- a/wagtailcomments_xtd/utils.py
+++ b/wagtailcomments_xtd/utils.py
@@ -1,4 +1,7 @@
-from django_comments_xtd.models import XtdComment
+from django_comments_xtd import get_model as get_comment_model
+
+
+XtdComment = get_comment_model()
 
 
 def cleaned_tree(comments):

--- a/wagtailcomments_xtd/views.py
+++ b/wagtailcomments_xtd/views.py
@@ -1,5 +1,5 @@
 from django.contrib import messages
-from wagtail.wagtailcore.models import Page
+from wagtail.core.models import Page
 from django.shortcuts import redirect, render
 from django_comments_xtd.models import XtdComment
 from django.utils.translation import ugettext as _

--- a/wagtailcomments_xtd/views.py
+++ b/wagtailcomments_xtd/views.py
@@ -1,9 +1,13 @@
 from django.contrib import messages
-from wagtail.core.models import Page
 from django.shortcuts import redirect, render
 from django_comments_xtd.models import XtdComment
 from django.utils.translation import ugettext as _
 from wagtailcomments_xtd.utils import cleaned_tree
+try:
+    from wagtail.wagtailcore.models import Page
+except ImportError:
+    # Wagtail 2.0+
+    from wagtail.core.models import Page
 
 
 def pages(request):

--- a/wagtailcomments_xtd/views.py
+++ b/wagtailcomments_xtd/views.py
@@ -1,6 +1,6 @@
 from django.contrib import messages
 from django.shortcuts import redirect, render
-from django_comments_xtd.models import XtdComment
+from django_comments_xtd import get_model as get_comment_model
 from django.utils.translation import ugettext as _
 from wagtailcomments_xtd.utils import cleaned_tree
 try:
@@ -8,6 +8,9 @@ try:
 except ImportError:
     # Wagtail 2.0+
     from wagtail.core.models import Page
+
+
+XtdComment = get_comment_model()
 
 
 def pages(request):

--- a/wagtailcomments_xtd/wagtail_hooks.py
+++ b/wagtailcomments_xtd/wagtail_hooks.py
@@ -5,10 +5,16 @@ except ImportError:
     # For Django 2.0+
     from django.urls import reverse 
 from wagtailcomments_xtd import urls
-from wagtail.core import hooks
 from django.conf.urls import include, url
-from wagtail.admin.menu import MenuItem
 from django.utils.translation import ugettext_lazy as _
+
+try:
+    from wagtail.wagtailcore import hooks
+    from wagtail.wagtailadmin.menu import MenuItem
+except ImportError:
+    # Wagtail 2.0+
+    from wagtail.core import hooks
+    from wagtail.admin.menu import MenuItem
 
 
 @hooks.register('register_admin_urls')

--- a/wagtailcomments_xtd/wagtail_hooks.py
+++ b/wagtailcomments_xtd/wagtail_hooks.py
@@ -5,9 +5,9 @@ except ImportError:
     # For Django 2.0+
     from django.urls import reverse 
 from wagtailcomments_xtd import urls
-from wagtail.wagtailcore import hooks
+from wagtail.core import hooks
 from django.conf.urls import include, url
-from wagtail.wagtailadmin.menu import MenuItem
+from wagtail.admin.menu import MenuItem
 from django.utils.translation import ugettext_lazy as _
 
 

--- a/wagtailcomments_xtd/wagtail_hooks.py
+++ b/wagtailcomments_xtd/wagtail_hooks.py
@@ -1,4 +1,9 @@
-from django.core import urlresolvers
+try:
+    # urlresolvers removed in Django 2.0:
+    from django.core.urlresolvers import reverse
+except ImportError:
+    # For Django 2.0+
+    from django.urls import reverse 
 from wagtailcomments_xtd import urls
 from wagtail.wagtailcore import hooks
 from django.conf.urls import include, url
@@ -17,7 +22,7 @@ def register_admin_urls():
 def register_styleguide_menu_item():
     return MenuItem(
         _('Comments'),
-        urlresolvers.reverse('wagtailcomments_xtd_pages'),
+        reverse('wagtailcomments_xtd_pages'),
         classnames='icon icon-fa-comments-o',
         order=1000
     )


### PR DESCRIPTION
Some fixes to get this working on Wagtail 2 (I'm using Wagtail 2.4 and Django 2.1).

* Fix imports that broke from Django 2.0+ (the fixes should still work with older versions of Django)
* Fix imports that broke from Wagtail 2.0+ (same)
* Replace broken use of `gravatar` template tag (which is not included) with `xtd_comment_gravtar_url`
* Fix layout of avatars in Wagtail admin (they were too big for current Wagtail)

Also:

* Allow the use of a custom django-comments-xtd comment model using the `COMMENTS_XTD_MODEL` setting
* Use relative dates for the list of comments in Wagtail admin, to be consistent with other admin lists
